### PR TITLE
Tidy up existing report

### DIFF
--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -31,9 +31,6 @@ section.section-overview.black-bg
   h2 Overview
   div.hero-stats
     article.hero-data
-      div#overview-grad-circle
-      p Percentage of students that graduated within 100% of published program length.
-    article.hero-data
       div#overview-employed-circle
       p Percentage of students employed in full time, paid field positions within 180 days of graduation.
     article.hero-data.hero-number
@@ -43,9 +40,6 @@ section.section-overview.black-bg
 section.section-graduation-data.blue-bg
   h2 Graduation Data
   div.hero-stats
-    article.hero-data
-      div#grad-data-reg-program-circle
-      p Percentage of students that graduated within 100% of published program length.
     article.hero-data
       div#grad-data-long-program-circle
       p Percentage of students that graduated within 150% of published program length.
@@ -213,44 +207,6 @@ section.section-employment-results
 
   h3 Percentage of job obtainers who reported salaries
   div.data-point 95%
-
-section.section-job-titles.blue-bg
-  h2 Frequent Job Titles
-  div.table-grid
-    article.table-data
-      p.heading Software Engineer
-      p.data-point 34%
-    article.table-data
-      p.heading Software Developer
-      p.data-point 23%
-    article.table-data
-      p.heading Developer
-      p.data-point 14%
-    article.table-data
-      p.heading Instructor
-      p.data-point 6%
-    article.table-data
-      p.heading Web Developer
-      p.data-point 3%
-    article.table-data
-      p.heading Full Stack Engineer
-      p.data-point 3%
-    article.table-data
-      p.heading QA / Tester
-      p.data-point 1%
-    article.table-data
-      p.heading Front End Engineer *
-      p.data-point 1%
-    article.table-data
-      p.heading Analyst
-      p.data-point 1%
-    article.table-data
-      p.heading Devops
-      p.data-point 1%
-    article.table-data
-      p.heading Other
-      p.data-point 3%
-    p.footnote * Graduates represented in this report precede the addition of the Front End Engineering Program
 
 section.section-cs-degree.black-bg
   h2 Students With Prior Computer Science Degree

--- a/source/javascripts/site.js
+++ b/source/javascripts/site.js
@@ -1,18 +1,6 @@
 $(document).ready(function() {
 
 //section-overview-data
-  $("#overview-grad-circle").circliful({
-      animation: 1,
-      animationStep: 5,
-      foregroundBorderWidth: 10,
-      backgroundBorderWidth: 10,
-      foregroundColor: '#f9ae06',
-      backgroundColor: '#4d4d4d',
-      percentageY: 110,
-      percent: 75,
-      textSize: 28,
-      fontColor: '#f9ae06'
-  });
   $("#overview-employed-circle").circliful({
       animation: 1,
       animationStep: 5,
@@ -27,18 +15,6 @@ $(document).ready(function() {
   });
 
 //section-graduation-data
-  $("#grad-data-reg-program-circle").circliful({
-      animation: 1,
-      animationStep: 5,
-      foregroundBorderWidth: 10,
-      backgroundBorderWidth: 10,
-      foregroundColor: '#0e6574',
-      backgroundColor: '#2adbe6',
-      percentageY: 110,
-      percent: 75,
-      textSize: 28,
-      fontColor: '#0e6574'
-  });
   $("#grad-data-long-program-circle").circliful({
       animation: 1,
       animationStep: 5,

--- a/source/stylesheets/_masthead.scss
+++ b/source/stylesheets/_masthead.scss
@@ -61,7 +61,7 @@
 
 @media #{$media-720px} {
   .masthead {
-    min-height: 50vh;
+    min-height: 40vh;
   }
   .logo-container {
     display: block;
@@ -71,6 +71,6 @@
 
 @media #{$media-1120px} {
   .masthead {
-    min-height: 70vh;
+    min-height: 50vh;
   }
 }

--- a/source/stylesheets/_sections.scss
+++ b/source/stylesheets/_sections.scss
@@ -54,15 +54,6 @@
   padding: 0;
 }
 
-.section-job-titles {
-  h2, p, .data-point-md {
-    color: $turing-color-dark;
-  }
-  .table-data {
-    border-color: $turing-color-dark;
-  }
-}
-
 .section-cs-degree {
   .data-point-md {
     margin-top: 40px;


### PR DESCRIPTION
Why:

* we are getting ready to add the newest numbers and want to tidy up a
  bit first

This change addresses the need by:

* Remove or shrink the height of the hero and the other big image.
* Remove frequent job titles.
* drop the 75% finish number (it's not representative)

https://trello.com/c/cFwcTzrA/38-update-latest-cirr-stats